### PR TITLE
build: add absolute imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,12 @@
     "allowJs": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./",
+    "paths": {
+      "src/*": [
+        "./src/*"
+      ]
+    },
 
     /* Bundler mode */
     "moduleResolution": "Node",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,11 @@ import { defineConfig } from 'vite';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      src: '/src',
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Major task

[GraphiQL App](https://github.com/rolling-scopes-school/tasks/blob/master/react/modules/graphiql.md)

## Task on the Kanban

none

## Description

### This PR adds possibility to use absolute paths instead of relative ones for your inports.
So now you can do this:
![image](https://github.com/Ivan-Gav/graphiql-app/assets/116670798/43301d75-5839-48a8-a370-f20c71fafbe1)
instead of this:
![image](https://github.com/Ivan-Gav/graphiql-app/assets/116670798/b1df3c5c-8c3c-488d-a852-5e6dc2f1a91e)

### But you still can use same old relative imports, if you want.

## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Refactor
- [ ] Test
- [x] Build
- [ ] Other

## Screenshot

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

