### PR TITLE
feat: display arguments for root types

### DIFF
--- a/src/components/DocumentationExplorer/Docs.tsx
+++ b/src/components/DocumentationExplorer/Docs.tsx
@@ -48,7 +48,7 @@ export default function Docs(props: { schema: GraphQLSchema | null }) {
           <DeviceHubRoundedIcon fontSize="small" />
           <Typography variant="subtitle1">{T.ROOT_TYPES}</Typography>
         </Grid>
-        <Stack spacing={2}>
+        <Stack>
           {!!queryType && (
             <Grid container px={2} textOverflow="ellipsis" overflow="hidden">
               <Typography
@@ -94,7 +94,7 @@ export default function Docs(props: { schema: GraphQLSchema | null }) {
           <Typography variant="subtitle1">{T.SCHEMA_TYPES}</Typography>
         </Grid>
       </Stack>
-      <Box flexGrow={1}>
+      <Box flexGrow={1} pl={2}>
         {!!filteredTypeMapArr && (
           <LazyList
             listLength={filteredTypeMapArr.length}

--- a/src/components/DocumentationExplorer/FieldLink.tsx
+++ b/src/components/DocumentationExplorer/FieldLink.tsx
@@ -1,9 +1,9 @@
-import { Grid, Link } from '@mui/material';
+import { Grid, Link, Stack, Typography } from '@mui/material';
 import { GraphQLNamedType } from 'graphql';
 import { useAppDispatch, useAppSelector } from 'src/hooks/redux';
 import { getDocState, setPath } from 'src/store/slice/DocSlice';
 import TypeLink from './TypeLink';
-import { FieldLinkProps } from 'src/models/models';
+import { CustomGraphQLType, FieldLinkProps } from 'src/models/models';
 
 export default function FieldLink(props: FieldLinkProps) {
   const { type } = props;
@@ -15,6 +15,42 @@ export default function FieldLink(props: FieldLinkProps) {
   const handleClick = (e: React.MouseEvent) => {
     if (e.target instanceof HTMLAnchorElement && e.target.textContent)
       dispatch(setPath([...path, e.target.textContent]));
+  };
+
+  const ArgList = (props: { type: CustomGraphQLType }) => {
+    const { type } = props;
+    const args: GraphQLNamedType[] | null =
+      'args' in type ? (type.args as GraphQLNamedType[]) : null;
+
+    if (!args || !args.length) return null;
+
+    return (
+      <>
+        <span>{' ('}</span>
+        {Object.values(args).map((arg) => {
+          return (
+            <Stack key={arg.name} pl={2}>
+              <Grid textOverflow="ellipsis" overflow="hidden">
+                <Typography
+                  component="span"
+                  variant="body1"
+                  color="info.main"
+                  noWrap
+                  title={arg.name}
+                >
+                  {arg.name}
+                </Typography>
+                <span>:&nbsp;</span>
+                {'type' in arg && !!arg.type && (
+                  <TypeLink type={arg.type as GraphQLNamedType} />
+                )}
+              </Grid>
+            </Stack>
+          );
+        })}
+        <span>{') '}</span>
+      </>
+    );
   };
 
   return (
@@ -30,6 +66,7 @@ export default function FieldLink(props: FieldLinkProps) {
       >
         {text}
       </Link>
+      <ArgList type={type} />
       <span>:&nbsp;</span>
       {!!type.type && <TypeLink type={type.type as GraphQLNamedType} />}
     </Grid>

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -16,6 +16,12 @@ const secondaryColor = {
   light: '#72a1ed',
 };
 
+const infoColor = {
+  main: '#F05B00',
+  dark: '#F03100',
+  light: '#F08500',
+};
+
 const textColor = {
   primary: '#e3e3e3',
   secondary: '#fff',
@@ -31,6 +37,7 @@ const theme = createTheme({
     text: textColor,
     primary: primaryColor,
     secondary: secondaryColor,
+    info: infoColor,
   },
   shadows: [
     'none',


### PR DESCRIPTION
## Major task

[GraphiQL App](https://github.com/rolling-scopes-school/tasks/blob/master/react/modules/graphiql.md)

## Task on the Kanban

[Update Schema Docs for queries (optional)](https://github.com/users/Ivan-Gav/projects/1?pane=issue&itemId=48448636)

## Description

This PR adds display of arguments for Root types. 

## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] Other

## Screenshot
### Before:
![image](https://github.com/Ivan-Gav/graphiql-app/assets/116670798/0bbbc00b-c24e-4c69-82ab-fb9dcda8aaa6)

### After:
![image](https://github.com/Ivan-Gav/graphiql-app/assets/116670798/813eae22-d121-446a-86b4-30b24ffb723b)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

