### PR TITLE
feat: add tests for Doc and DocBreadCrumbs components (part 1)

### DIFF
--- a/src/__tests__/Doc.test.tsx
+++ b/src/__tests__/Doc.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { schema } from './mockSchema';
+import { Provider } from 'react-redux';
+import { useAppSelector } from 'src/hooks/redux';
+import LangContextProvider from 'src/context/LangContext';
+import { store } from 'src/store/store';
+import Doc from 'src/components/DocumentationExplorer/Doc';
+import TEXT from 'src/constants/text';
+
+describe('Doc component', () => {
+  vi.mock('src/hooks/redux');
+  vi.mocked(useAppSelector).mockReturnValue({
+    docPath: ['Docs', 'User', 'id'],
+  });
+
+  const WrappedDocComponent = (props: { item: string }) => {
+    return (
+      <LangContextProvider>
+        <Provider store={store}>
+          <Doc schema={schema} item={props.item} />
+        </Provider>
+      </LangContextProvider>
+    );
+  };
+
+  it('renders item', () => {
+    render(<WrappedDocComponent item="id" />);
+
+    const itemTitle = screen.getByRole('heading', { level: 3 });
+
+    expect(itemTitle).toHaveTextContent('id');
+  });
+
+  it("throws an error if type isn't found", () => {
+    const r = () => render(<WrappedDocComponent item="nonono" />);
+
+    expect(r).toThrowError(`${TEXT.EN.CANT_FIND_FIELD}"nonono"`);
+  });
+});

--- a/src/__tests__/DocBreadCrumbs.test.tsx
+++ b/src/__tests__/DocBreadCrumbs.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Provider } from 'react-redux';
+import { useAppSelector } from 'src/hooks/redux';
+import LangContextProvider from 'src/context/LangContext';
+import { store } from 'src/store/store';
+import DocBreadCrumbs from 'src/components/DocumentationExplorer/DocBreadCrumbs';
+import * as modReduxHooks from 'src/hooks/redux';
+import * as actions from 'src/store/slice/DocSlice';
+
+describe('Doc component', () => {
+  vi.mock('src/hooks/redux');
+  vi.mocked(useAppSelector).mockReturnValue({
+    docPath: ['Docs', 'User', 'id'],
+  });
+
+  const WrappedBCComponent = () => {
+    return (
+      <LangContextProvider>
+        <Provider store={store}>
+          <DocBreadCrumbs />
+        </Provider>
+      </LangContextProvider>
+    );
+  };
+
+  it('renders bread crumb link', () => {
+    render(<WrappedBCComponent />);
+    const bcLink = screen.getByRole('link', { name: 'User' });
+
+    expect(bcLink).toBeVisible();
+  });
+
+  it('dispatches action when clicked', () => {
+    const dispatch = vi.fn();
+    const mockedDispatch = vi.spyOn(modReduxHooks, 'useAppDispatch');
+    mockedDispatch.mockReturnValue(dispatch);
+
+    const mockedSetPath = vi.spyOn(actions, 'setPath');
+
+    render(<WrappedBCComponent />);
+    const bcLink = screen.getByRole('link', { name: 'User' });
+
+    fireEvent.click(bcLink);
+
+    expect(dispatch).toHaveBeenCalled();
+    expect(mockedSetPath).toHaveBeenCalledWith(['Docs', 'User']);
+  });
+});

--- a/src/__tests__/Docx.test.tsx
+++ b/src/__tests__/Docx.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GraphQLSchema } from 'graphql';
+import { Provider } from 'react-redux';
+import { schema } from './mockSchema';
+import LangContextProvider from 'src/context/LangContext';
+import Docs from 'src/components/DocumentationExplorer/Docs';
+import { store } from 'src/store/store';
+
+const WrappedDocsComponent = (props: { schema: GraphQLSchema | null }) => {
+  return (
+    <LangContextProvider>
+      <Provider store={store}>
+        <Docs schema={props.schema} />
+      </Provider>
+    </LangContextProvider>
+  );
+};
+
+describe('Docs', () => {
+  it('renders heading', () => {
+    render(<WrappedDocsComponent schema={schema} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Docs', level: 3 })
+    ).toBeVisible();
+  });
+});

--- a/src/__tests__/mockSchema.ts
+++ b/src/__tests__/mockSchema.ts
@@ -1,0 +1,12 @@
+import { buildSchema } from 'graphql';
+
+export const schema = buildSchema(`
+  type User {
+    id: ID!
+    firstName: String!
+  }
+ 
+  type Query {
+    user(id: ID!): User
+  }
+`);


### PR DESCRIPTION
## Major task

[GraphiQL App](https://github.com/rolling-scopes-school/tasks/blob/master/react/modules/graphiql.md)

## Task on the Kanban

[ Write tests for Documentation (schema) component](https://github.com/users/Ivan-Gav/projects/1?pane=issue&itemId=48365318)

## Description

This PR adds tests for following: components:
- Doc
- DocBreadCrumbs 

## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Refactor
- [x] Test
- [ ] Build
- [ ] Other

## Screenshot

not needed

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

