### PR TITLE
feat: Add Error Message for failed API

### DIFF
--- a/src/__tests__/SignUpPage.test.tsx
+++ b/src/__tests__/SignUpPage.test.tsx
@@ -147,7 +147,6 @@ describe('Page SignUp', () => {
     renderComponent('/');
 
     const firstNameInput = screen.getByTestId('first-name-input');
-    const lastNameInput = screen.getByTestId('last-name-input');
     const emailInput = screen.getByTestId('email-input');
     const passwordInput = screen.getByTestId('password-input');
 
@@ -155,7 +154,6 @@ describe('Page SignUp', () => {
 
     await act(async () => {
       fireEvent.input(firstNameInput, { target: { value: 'Firstname' } });
-      fireEvent.input(lastNameInput, { target: { value: 'Lastname' } });
       fireEvent.input(emailInput, { target: { value: 'test@gmail.com' } });
       fireEvent.input(passwordInput, { target: { value: '@Qwerty123' } });
     });

--- a/src/components/ResponseSection/ResponseSection.tsx
+++ b/src/components/ResponseSection/ResponseSection.tsx
@@ -8,6 +8,7 @@ import {
 } from 'src/store/slice/RequestSlice';
 import { createTheme } from '@uiw/codemirror-themes';
 import { EditorView } from '@codemirror/view';
+import { clearApiState, getGraphqlState } from 'src/store/slice/graphql.slice';
 
 const scrollStyle = EditorView.theme(
   {
@@ -46,10 +47,13 @@ export default function ResponseSection() {
   const { responseString, errorMessageApi, errorMessage } =
     useAppSelector(getRequestState);
 
+  const { errorMessage: errorMessageApiUrl } = useAppSelector(getGraphqlState);
+
   const dispatch = useAppDispatch();
 
   const handleClose = () => {
     dispatch(deleteMessageError());
+    dispatch(clearApiState());
   };
 
   return (
@@ -68,11 +72,11 @@ export default function ResponseSection() {
       </Typography>
       <Snackbar
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-        open={errorMessage ? true : false}
+        open={errorMessage || errorMessageApiUrl ? true : false}
         onClose={handleClose}
       >
         <Alert severity="error" elevation={6} variant="filled">
-          {errorMessage}
+          {errorMessage || errorMessageApiUrl}
         </Alert>
       </Snackbar>
     </Paper>


### PR DESCRIPTION

## Major task

[GraphiQL App](https://github.com/rolling-scopes-school/tasks/blob/master/react/modules/graphiql.md)

## Task on the Kanban

[Task title](https://github.com/Ivan-Gav/graphiql-app/issues/82)

## Description

This PR add Error Message for failed API Endpoint request. 

## What type of PR is this? (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] Other

## Screenshot

![image](https://github.com/Ivan-Gav/graphiql-app/assets/119886378/5b60da5f-c84c-419c-9a6e-1e1e2a08191c)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

