### PR TITLE
Localize default schema description

### DIFF
--- a/src/components/DocumentationExplorer/Docs.tsx
+++ b/src/components/DocumentationExplorer/Docs.tsx
@@ -18,9 +18,7 @@ export default function Docs(props: { schema: GraphQLSchema | null }) {
   const subscriptionType = schema?.getSubscriptionType?.() || null;
   const typeMap = useMemo(() => schema?.getTypeMap() || null, [schema]);
 
-  const schemaDescription =
-    schema?.description ||
-    'A GraphQL schema provides a root type for each kind of operation.';
+  const schemaDescription = schema?.description || T.SCHEMA_DEFAULT_DESCRIPTION;
   const ignoreTypes = useMemo(
     () => [queryType?.name, mutationType?.name, subscriptionType?.name],
     [queryType, mutationType, subscriptionType]

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -51,6 +51,8 @@ const TEXT = {
     YUP_TANDC: 'Rules not accepted',
     INPUT_API: 'Enter API Endpoint',
     NOT_SELECTED_API: 'API not selected',
+    SCHEMA_DEFAULT_DESCRIPTION:
+      'A GraphQL schema provides a root type for each kind of operation.',
     ROOT_TYPES: 'Root Types',
     SCHEMA_TYPES: 'All Schema Types',
     ENUM_VALUES: 'Enum Values',
@@ -120,6 +122,8 @@ const TEXT = {
     YUP_TANDC: 'Забыли поставить галочку',
     INPUT_API: 'Введите адрес API',
     NOT_SELECTED_API: 'Не выбран API',
+    SCHEMA_DEFAULT_DESCRIPTION:
+      'Схема GraphQL описывает корневые типы для каждого вида операций.',
     ROOT_TYPES: 'Корневые типы',
     SCHEMA_TYPES: 'Все типы',
     ENUM_VALUES: 'Значения Enum',


### PR DESCRIPTION
## Major task

[GraphiQL App](https://github.com/rolling-scopes-school/tasks/blob/master/react/modules/graphiql.md)

## Task on the Kanban

[Add localization for default Docs description](https://github.com/users/Ivan-Gav/projects/1/views/1?pane=issue&itemId=49133265)

## Description

This PR adds localization for default schema description. 

## What type of PR is this? (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] Other

## Screenshot
![image](https://github.com/Ivan-Gav/graphiql-app/assets/116670798/c7ab7d41-c2e4-45b4-9088-b0c97af37f58)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

